### PR TITLE
fix: Handle missing cloudExternalId in SCIM 2.0 source connectors

### DIFF
--- a/identitynow/resources/source/source_data_source.go
+++ b/identitynow/resources/source/source_data_source.go
@@ -162,8 +162,18 @@ func (d *SourceDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 	data.Name = types.StringValue(source.Name)
 	data.Description = types.StringPointerValue(source.Description)
 
+	// Safe type assertion for cloudExternalId to handle SCIM 2.0 sources that don't have this field
+	cloudExternalIdValue := types.StringNull()
+	if source.ConnectorAttributes != nil {
+		if cloudExtId, exists := source.ConnectorAttributes["cloudExternalId"]; exists && cloudExtId != nil {
+			if strVal, ok := cloudExtId.(string); ok {
+				cloudExternalIdValue = types.StringValue(strVal)
+			}
+		}
+	}
+
 	cAttr, ok := types.ObjectValue(connectorAttributesTypes, map[string]attr.Value{
-		"cloud_external_id": types.StringValue(source.ConnectorAttributes["cloudExternalId"].(string)),
+		"cloud_external_id": cloudExternalIdValue,
 	})
 	if ok.HasError() {
 		resp.Diagnostics.Append(ok...)


### PR DESCRIPTION
Adds safe type assertion with nil checking for the cloudExternalId field in source connector attributes. SCIM 2.0 connectors do not include this field, causing runtime panics on unsafe type assertions.

Changes:
- Replace unsafe type assertion with proper nil checking
- Return StringNull() for missing or nil cloudExternalId values
- Maintain backward compatibility for sources that do have the field

Addresses #1