### PR TITLE
feat: Add identitynow_entitlements data source with filtering support

### DIFF
--- a/identitynow/provider.go
+++ b/identitynow/provider.go
@@ -148,6 +148,7 @@ func (p *Provider) Resources(ctx context.Context) []func() resource.Resource {
 func (p *Provider) DataSources(ctx context.Context) []func() datasource.DataSource {
 	return []func() datasource.DataSource{
 		entitlement.NewEntitlementDataSource,
+		entitlement.NewEntitlementsDataSource,
 		source.NewSourceDataSource,
 		identity.NewIdentityDataSource,
 		accessprofile.NewAccessProfileDataSource,

--- a/identitynow/resources/entitlement/entitlement_data_source.go
+++ b/identitynow/resources/entitlement/entitlement_data_source.go
@@ -7,7 +7,6 @@ import (
 	sailpoint "github.com/davidsonjon/golang-sdk/v2"
 	beta "github.com/davidsonjon/golang-sdk/v2/api_beta"
 	"github.com/davidsonjon/terraform-provider-identitynow/identitynow/config"
-	"github.com/davidsonjon/terraform-provider-identitynow/identitynow/resources/metadataattribute"
 	"github.com/davidsonjon/terraform-provider-identitynow/identitynow/util"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
@@ -31,132 +30,18 @@ func (d *EntitlementDataSource) Metadata(ctx context.Context, req datasource.Met
 }
 
 func (d *EntitlementDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	// Get the shared entitlement schema attributes
+	attributes := GetEntitlementSchemaAttributes()
+	
+	// Override the 'id' attribute to be required for the single entitlement data source
+	attributes["id"] = schema.StringAttribute{
+		Required:            true,
+		MarkdownDescription: "The entitlement id",
+	}
+
 	resp.Schema = schema.Schema{
 		MarkdownDescription: "Entitlement data source",
-
-		Attributes: map[string]schema.Attribute{
-			"id": schema.StringAttribute{
-				Required:            true,
-				MarkdownDescription: "The entitlement id",
-			},
-			"name": schema.StringAttribute{
-				Computed:            true,
-				MarkdownDescription: "The entitlement name",
-			},
-			"created": schema.StringAttribute{
-				Computed:            true,
-				MarkdownDescription: "Time when the entitlement was created",
-			},
-			"modified": schema.StringAttribute{
-				Computed:            true,
-				MarkdownDescription: "Time when the entitlement was last modified",
-			},
-			"attribute": schema.StringAttribute{
-				Computed:            true,
-				MarkdownDescription: "The entitlement attribute name",
-			},
-			"value": schema.StringAttribute{
-				Computed:            true,
-				MarkdownDescription: "The value of the entitlement",
-			},
-			"source_schema_object_type": schema.StringAttribute{
-				Computed:            true,
-				MarkdownDescription: "The object type of the entitlement from the source schema",
-			},
-			"privileged": schema.BoolAttribute{
-				Computed:            true,
-				MarkdownDescription: "True if the entitlement is privileged",
-			},
-			"cloud_governed": schema.BoolAttribute{
-				Computed:            true,
-				MarkdownDescription: "True if the entitlement is cloud governed",
-			},
-			"description": schema.StringAttribute{
-				Computed:            true,
-				MarkdownDescription: "The description of the entitlement, due to API limitations, may be set to an empty string (`\"\"`) but not **null**. Note: this attribute can be initially aggregated in from some sources and will be overwritten if set",
-			},
-			"requestable": schema.BoolAttribute{
-				Computed:            true,
-				MarkdownDescription: "True if the entitlement is requestable",
-			},
-			"source_id": schema.StringAttribute{
-				Computed:            true,
-				MarkdownDescription: "The Source ID of the entitlement",
-			},
-			"owner": schema.SingleNestedAttribute{
-				MarkdownDescription: "The Owner of the entitlement",
-				Attributes: map[string]schema.Attribute{
-					"id": schema.StringAttribute{
-						Computed:            true,
-						MarkdownDescription: "Identity id",
-					},
-					"name": schema.StringAttribute{
-						Computed:            true,
-						MarkdownDescription: "Human-readable display name of the owner. It may be left null or omitted in a POST or PATCH. If set, it must match the current value of the owner's display name, otherwise a 400 Bad Request error will result.",
-					},
-					"type": schema.StringAttribute{
-						Computed:            true,
-						MarkdownDescription: "The type of the Source, will always be `IDENTITY`",
-					},
-				},
-				Computed: true,
-			},
-			"access_model_metadata": schema.ListNestedAttribute{
-				Computed: true,
-				NestedObject: schema.NestedAttributeObject{
-					Attributes: map[string]schema.Attribute{
-						"key": schema.StringAttribute{
-							Computed:            true,
-							MarkdownDescription: "Technical name of the Attribute. This is unique and cannot be changed after creation.",
-						},
-						"name": schema.StringAttribute{
-							Computed:            true,
-							MarkdownDescription: "The display name of the key.",
-						},
-						"multiselect": schema.BoolAttribute{
-							Computed:            true,
-							MarkdownDescription: "Indicates whether the attribute can have multiple values.",
-						},
-						"status": schema.StringAttribute{
-							Computed:            true,
-							MarkdownDescription: "The status of the Attribute.",
-						},
-						"type": schema.StringAttribute{
-							Computed:            true,
-							MarkdownDescription: "The type of the Attribute. This can be either `custom` or `governance`.",
-						},
-						"object_types": schema.ListAttribute{
-							ElementType:         types.StringType,
-							Computed:            true,
-							MarkdownDescription: "An array of object types this attributes values can be applied to. Possible values are `all` or `entitlement`. Value `all` means this attribute can be used with all object types that are supported.",
-						},
-						"description": schema.StringAttribute{
-							Computed:            true,
-							MarkdownDescription: "The description of the Attribute.",
-						},
-						"values": schema.ListNestedAttribute{
-							NestedObject: schema.NestedAttributeObject{
-								Attributes: map[string]schema.Attribute{
-									"value": schema.StringAttribute{
-										Computed:            true,
-										MarkdownDescription: "Technical name of the Attribute value. This is unique and cannot be changed after creation.",
-									},
-									"name": schema.StringAttribute{
-										Computed:            true,
-										MarkdownDescription: "The display name of the Attribute value.",
-									},
-									"status": schema.StringAttribute{
-										Computed:            true,
-										MarkdownDescription: "The status of the Attribute value.",
-									},
-								},
-							},
-							Computed: true,
-						},
-					},
-				},
-			},
-		},
+		Attributes:          attributes,
 	}
 }
 
@@ -207,65 +92,28 @@ func (d *EntitlementDataSource) Read(ctx context.Context, req datasource.ReadReq
 		return
 	}
 
-	parseAttributes(&data, entitlement, &resp.Diagnostics)
+	// Use the shared conversion function
+	convertedEntitlement, diags := ConvertBetaEntitlementToModel(ctx, *entitlement)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Copy the converted data, but preserve the original ID from the request
+	data = convertedEntitlement
+	data.Id = types.StringValue(data.Id.ValueString()) // Ensure ID is set
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
+// parseAttributes is a wrapper function to maintain compatibility with entitlement_resource.go
+// This function is deprecated and should be replaced with ConvertBetaEntitlementToModel
 func parseAttributes(ent *Entitlement, betaEnt *beta.Entitlement, diags *diag.Diagnostics) {
-	ent.Id = types.StringPointerValue(betaEnt.Id)
-	ent.Name = types.StringPointerValue(betaEnt.Name)
-	ent.Created = types.StringValue(betaEnt.Created.String())
-	ent.Modified = types.StringValue(betaEnt.Modified.String())
-	ent.Attribute = types.StringPointerValue(betaEnt.Attribute.Get())
-	ent.Value = types.StringPointerValue(betaEnt.Value)
-	ent.SourceSchemaObjectType = types.StringPointerValue(betaEnt.SourceSchemaObjectType)
-	ent.Privileged = types.BoolPointerValue(betaEnt.Privileged)
-	ent.CloudGoverned = types.BoolPointerValue(betaEnt.CloudGoverned)
-	ent.Description = types.StringPointerValue(betaEnt.Description.Get())
-	ent.Requestable = types.BoolPointerValue(betaEnt.Requestable)
-
-	ent.SourceID = types.StringPointerValue(betaEnt.Source.Id)
-
-	if betaEnt.Owner != nil {
-		owner := &OwnerReference{}
-		owner.Id = types.StringPointerValue(betaEnt.Owner.Id)
-		owner.Name = types.StringPointerValue(betaEnt.Owner.Name)
-		owner.Type = types.StringPointerValue(betaEnt.Owner.Type)
-
-		ent.Owner = owner
+	convertedEnt, convertDiags := ConvertBetaEntitlementToModel(context.Background(), *betaEnt)
+	diags.Append(convertDiags...)
+	if diags.HasError() {
+		return
 	}
-
-	if len(betaEnt.AccessModelMetadata.Attributes) > 0 {
-		metadata := []metadataattribute.AttributeDTO{}
-
-		for _, att := range betaEnt.AccessModelMetadata.Attributes {
-			metatdataAtts := metadataattribute.AttributeDTO{}
-			metatdataAtts.Key = types.StringPointerValue(att.Key)
-			metatdataAtts.Name = types.StringPointerValue(att.Name)
-			metatdataAtts.Multiselect = types.BoolPointerValue(att.Multiselect)
-			metatdataAtts.Status = types.StringPointerValue(att.Status)
-			metatdataAtts.Type = types.StringPointerValue(att.Type)
-			metatdataAtts.Description = types.StringPointerValue(att.Description)
-
-			objectTypes, diags1 := types.ListValueFrom(context.Background(), types.StringType, att.ObjectTypes)
-			metatdataAtts.ObjectTypes = objectTypes
-			diags.Append(diags1...)
-
-			for _, v := range att.Values {
-				value := &metadataattribute.AttributeValueDTO{
-					Value:  types.StringPointerValue(v.Value),
-					Name:   types.StringPointerValue(v.Name),
-					Status: types.StringPointerValue(v.Status),
-				}
-				metatdataAtts.Values = append(metatdataAtts.Values, *value)
-
-			}
-			metadata = append(metadata, metatdataAtts)
-
-		}
-
-		ent.AccessModelMetadata = metadata
-	}
-
+	*ent = convertedEnt
 }
+

--- a/identitynow/resources/entitlement/entitlement_schema.go
+++ b/identitynow/resources/entitlement/entitlement_schema.go
@@ -1,0 +1,134 @@
+package entitlement
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// GetEntitlementSchemaAttributes returns the common schema attributes used by both
+// the single entitlement data source and the multiple entitlements data source
+func GetEntitlementSchemaAttributes() map[string]schema.Attribute {
+	return map[string]schema.Attribute{
+		"id": schema.StringAttribute{
+			Computed:            true,
+			MarkdownDescription: "The entitlement id",
+		},
+		"name": schema.StringAttribute{
+			Computed:            true,
+			MarkdownDescription: "The entitlement name",
+		},
+		"created": schema.StringAttribute{
+			Computed:            true,
+			MarkdownDescription: "Time when the entitlement was created",
+		},
+		"modified": schema.StringAttribute{
+			Computed:            true,
+			MarkdownDescription: "Time when the entitlement was last modified",
+		},
+		"attribute": schema.StringAttribute{
+			Computed:            true,
+			MarkdownDescription: "The entitlement attribute name",
+		},
+		"value": schema.StringAttribute{
+			Computed:            true,
+			MarkdownDescription: "The value of the entitlement",
+		},
+		"source_schema_object_type": schema.StringAttribute{
+			Computed:            true,
+			MarkdownDescription: "The object type of the entitlement from the source schema",
+		},
+		"privileged": schema.BoolAttribute{
+			Computed:            true,
+			MarkdownDescription: "True if the entitlement is privileged",
+		},
+		"cloud_governed": schema.BoolAttribute{
+			Computed:            true,
+			MarkdownDescription: "True if the entitlement is cloud governed",
+		},
+		"description": schema.StringAttribute{
+			Computed:            true,
+			MarkdownDescription: "The description of the entitlement, due to API limitations, may be set to an empty string (`\"\"`) but not **null**. Note: this attribute can be initially aggregated in from some sources and will be overwritten if set",
+		},
+		"requestable": schema.BoolAttribute{
+			Computed:            true,
+			MarkdownDescription: "True if the entitlement is requestable",
+		},
+		"source_id": schema.StringAttribute{
+			Computed:            true,
+			MarkdownDescription: "The Source ID of the entitlement",
+		},
+		"owner": schema.SingleNestedAttribute{
+			MarkdownDescription: "The Owner of the entitlement",
+			Attributes: map[string]schema.Attribute{
+				"id": schema.StringAttribute{
+					Computed:            true,
+					MarkdownDescription: "Identity id",
+				},
+				"name": schema.StringAttribute{
+					Computed:            true,
+					MarkdownDescription: "Human-readable display name of the owner. It may be left null or omitted in a POST or PATCH. If set, it must match the current value of the owner's display name, otherwise a 400 Bad Request error will result.",
+				},
+				"type": schema.StringAttribute{
+					Computed:            true,
+					MarkdownDescription: "The type of the Source, will always be `IDENTITY`",
+				},
+			},
+			Computed: true,
+		},
+		"access_model_metadata": schema.ListNestedAttribute{
+			Computed: true,
+			NestedObject: schema.NestedAttributeObject{
+				Attributes: map[string]schema.Attribute{
+					"key": schema.StringAttribute{
+						Computed:            true,
+						MarkdownDescription: "Technical name of the Attribute. This is unique and cannot be changed after creation.",
+					},
+					"name": schema.StringAttribute{
+						Computed:            true,
+						MarkdownDescription: "The display name of the key.",
+					},
+					"multiselect": schema.BoolAttribute{
+						Computed:            true,
+						MarkdownDescription: "Indicates whether the attribute can have multiple values.",
+					},
+					"status": schema.StringAttribute{
+						Computed:            true,
+						MarkdownDescription: "The status of the Attribute.",
+					},
+					"type": schema.StringAttribute{
+						Computed:            true,
+						MarkdownDescription: "The type of the Attribute. This can be either `custom` or `governance`.",
+					},
+					"object_types": schema.ListAttribute{
+						ElementType:         types.StringType,
+						Computed:            true,
+						MarkdownDescription: "An array of object types this attributes values can be applied to. Possible values are `all` or `entitlement`. Value `all` means this attribute can be used with all object types that are supported.",
+					},
+					"description": schema.StringAttribute{
+						Computed:            true,
+						MarkdownDescription: "The description of the Attribute.",
+					},
+					"values": schema.ListNestedAttribute{
+						NestedObject: schema.NestedAttributeObject{
+							Attributes: map[string]schema.Attribute{
+								"value": schema.StringAttribute{
+									Computed:            true,
+									MarkdownDescription: "Technical name of the Attribute value. This is unique and cannot be changed after creation.",
+								},
+								"name": schema.StringAttribute{
+									Computed:            true,
+									MarkdownDescription: "The display name of the Attribute value.",
+								},
+								"status": schema.StringAttribute{
+									Computed:            true,
+									MarkdownDescription: "The status of the Attribute value.",
+								},
+							},
+						},
+						Computed: true,
+					},
+				},
+			},
+		},
+	}
+}

--- a/identitynow/resources/entitlement/entitlements_data_source.go
+++ b/identitynow/resources/entitlement/entitlements_data_source.go
@@ -1,0 +1,182 @@
+package entitlement
+
+import (
+	"context"
+	"fmt"
+
+	sailpoint "github.com/davidsonjon/golang-sdk/v2"
+	"github.com/davidsonjon/terraform-provider-identitynow/identitynow/config"
+	"github.com/davidsonjon/terraform-provider-identitynow/identitynow/util"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+var _ datasource.DataSource = &EntitlementsDataSource{}
+
+func NewEntitlementsDataSource() datasource.DataSource {
+	return &EntitlementsDataSource{}
+}
+
+type EntitlementsDataSource struct {
+	client *sailpoint.APIClient
+}
+
+// EntitlementsDataSourceModel represents the data source configuration model
+type EntitlementsDataSourceModel struct {
+	Filter       types.String `tfsdk:"filter"`
+	SourceID     types.String `tfsdk:"source_id"`
+	Limit        types.Int64  `tfsdk:"limit"`
+	Entitlements types.List   `tfsdk:"entitlements"`
+}
+
+func (d *EntitlementsDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_entitlements"
+}
+
+func (d *EntitlementsDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	// Get the shared entitlement schema attributes
+	entitlementAttributes := GetEntitlementSchemaAttributes()
+	
+	resp.Schema = schema.Schema{
+		MarkdownDescription: "Entitlements data source for querying multiple entitlements with filter support",
+
+		Attributes: map[string]schema.Attribute{
+			"filter": schema.StringAttribute{
+				Optional:            true,
+				MarkdownDescription: "Filter expression to query entitlements (e.g., 'source.id eq \"xxx\"')",
+			},
+			"source_id": schema.StringAttribute{
+				Optional:            true,
+				MarkdownDescription: "Source ID to filter entitlements (convenience field for source.id filter)",
+			},
+			"limit": schema.Int64Attribute{
+				Optional:            true,
+				MarkdownDescription: "Maximum number of entitlements to return (default: 250)",
+			},
+			"entitlements": schema.ListNestedAttribute{
+				Computed:            true,
+				MarkdownDescription: "List of entitlements matching the filter criteria",
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: entitlementAttributes,
+				},
+			},
+		},
+	}
+}
+
+func (d *EntitlementsDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	config, ok := req.ProviderData.(config.ProviderConfig)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected config.ProviderConfig, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+
+	d.client = config.APIClient
+}
+
+func (d *EntitlementsDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data EntitlementsDataSourceModel
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Build filter from either explicit filter or source_id convenience field
+	var filter string
+	if !data.Filter.IsNull() && !data.Filter.IsUnknown() {
+		filter = data.Filter.ValueString()
+	} else if !data.SourceID.IsNull() && !data.SourceID.IsUnknown() {
+		filter = fmt.Sprintf(`source.id eq "%s"`, data.SourceID.ValueString())
+	}
+
+	// Set default limit if not specified
+	limit := int32(250)
+	if !data.Limit.IsNull() && !data.Limit.IsUnknown() {
+		limit = int32(data.Limit.ValueInt64())
+	}
+
+	// Call the ListEntitlements API
+	apiRequest := d.client.Beta.EntitlementsAPI.ListEntitlements(ctx)
+	if filter != "" {
+		apiRequest = apiRequest.Filters(filter)
+	}
+	apiRequest = apiRequest.Limit(limit)
+
+	entitlements, httpResp, err := apiRequest.Execute()
+	if err != nil {
+		sailpointError, isSailpointError := util.SailpointErrorFromHTTPBody(httpResp)
+		if isSailpointError {
+			resp.Diagnostics.AddError(
+				"Error when calling Beta.EntitlementsAPI.ListEntitlements",
+				fmt.Sprintf("Error: %s", *sailpointError.GetMessages()[0].Text),
+			)
+		} else {
+			resp.Diagnostics.AddError(
+				"Error when calling Beta.EntitlementsAPI.ListEntitlements",
+				fmt.Sprintf("Error: %s, see debug info for more information", err),
+			)
+		}
+		tflog.Info(ctx, fmt.Sprintf("Full HTTP response: %v", httpResp))
+		return
+	}
+
+	// Convert entitlements using the shared conversion function
+	var entitlementModels []Entitlement
+	for _, entitlement := range entitlements {
+		entitlementModel, diags := ConvertBetaEntitlementToModel(ctx, entitlement)
+		resp.Diagnostics.Append(diags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		entitlementModels = append(entitlementModels, entitlementModel)
+	}
+
+	// Convert to Terraform list type
+	entitlementsList, listDiags := types.ListValueFrom(ctx, types.ObjectType{
+		AttrTypes: getEntitlementObjectAttrTypes(),
+	}, entitlementModels)
+	resp.Diagnostics.Append(listDiags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	data.Entitlements = entitlementsList
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+// getEntitlementObjectAttrTypes returns the attribute types for the Entitlement object
+// This uses the existing types from the model
+func getEntitlementObjectAttrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"id":                        types.StringType,
+		"name":                      types.StringType,
+		"created":                   types.StringType,
+		"modified":                  types.StringType,
+		"attribute":                 types.StringType,
+		"value":                     types.StringType,
+		"source_schema_object_type": types.StringType,
+		"privileged":                types.BoolType,
+		"cloud_governed":            types.BoolType,
+		"description":               types.StringType,
+		"requestable":               types.BoolType,
+		"source_id":                 types.StringType,
+		"owner": types.ObjectType{
+			AttrTypes: OwnerSchemeObject,
+		},
+		"access_model_metadata": types.ListType{
+			ElemType: AttributeDTOObject,
+		},
+	}
+}


### PR DESCRIPTION
Implements a new data source for querying multiple entitlements with filter capabilities, complementing the existing single entitlement lookup by ID.

Features:
- Query entitlements by source_id (convenience parameter)
- Support for advanced SailPoint filter expressions
- Configurable result limits (default: 250)
- Returns list of entitlement objects with same schema as single lookup

Implementation details:
- Created shared GetEntitlementSchemaAttributes() function to eliminate duplication
- Added ConvertBetaEntitlementToModel() shared conversion function
- Refactored existing entitlement_data_source.go to use shared functions
- Maintains backward compatibility with existing resource usage

Example usage:
```hcl
data "identitynow_entitlements" "source_entitlements" {
  source_id = "8b649d6daee1407ca0df6b491c82f74b"
  limit     = 10
}
```

Addresses #3